### PR TITLE
Added support for reverse geocoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,13 @@ Geo is a very basic, but simple, geo library for Node.js using Google's Geocode 
 			console.log("Longitude: " + longitude);
 		});
 		
-
+		// Reverse Geocoding also works
+		var latlong = { 'latitude': 52.5112, 'longitude': 13.45155};
+		geo.geocoder(geo.google, latlong, sensor, function(formattedAddress, latitude, longitude) {
+			console.log("Formatted Address: " + formattedAddress);
+			console.log("Latitude: " + latitude);
+			console.log("Longitude: " + longitude);
+		});
 		
 ## Usage - GeoHash
 

--- a/examples/simple_reverse_geocode_lookup.js
+++ b/examples/simple_reverse_geocode_lookup.js
@@ -1,0 +1,30 @@
+// *********************************************
+// *********************************************
+// Geo by Felipe Oliveira
+// March 2011
+// http://geeks.aretotally.in/projects/geo
+// http://twitter.com/_felipera
+// *********************************************
+// *********************************************
+
+var geo = require('../lib/geo');
+
+// Reverse Geocoding also works
+var latlong = { 'latitude': 52.5112, 'longitude': 13.45155};
+geo.geocoder(geo.google, latlong, sensor, function(formattedAddress, latitude, longitude) {
+	console.log("Formatted Address: " + formattedAddress);
+	console.log("Latitude: " + latitude);
+	console.log("Longitude: " + longitude);
+});
+
+
+// Bad Address
+// var address = '1111 Foobar Ave #15D New York, NY 9999';
+// var sensor = false;
+// geo.geocoder(geo.google, address, sensor, function(formattedAddress, latitude, longitude) {
+	// console.log("Formatted Address: " + formattedAddress);
+	// console.log("Latitude: " + latitude);
+	// console.log("Longitude: " + longitude);
+// });
+
+

--- a/lib/geo.js
+++ b/lib/geo.js
@@ -19,10 +19,18 @@ function GoogleGeocoder() {};
 
 // Google Geocode Provider - Request
 GoogleGeocoder.prototype.request = function(location, sensor) {
+  if (typeof location == 'object' && location['latitude'] != null && location['longitude'] != null) {
+    // if location is an object with lat and long properties, we do reverse geocoding
+    var path = '/maps/api/geocode/json?latlng=' + escape(location['latitude'].toString() + ',' + location['longitude'].toString()) + '&sensor=' + sensor;
+  } else {
+    // normal forward geocoding
+    var path = '/maps/api/geocode/json?address=' + escape(location) + '&sensor=' + sensor;
+  }
+
 	return {
 		host: 'maps.googleapis.com',
 		port: 80,
-		path: '/maps/api/geocode/json?address=' + escape(location) + '&sensor=' + sensor,
+		path: path,
 		method: 'GET'
 	};
 };


### PR DESCRIPTION
You can do reverse lookups now by supplying a {'latitude': someLat, 'longitude': someLong} instead of an address string to find out an address if you have the exact location.
