### PR TITLE
Switch to use Shred to support setting a timeout for geocoding

### DIFF
--- a/lib/geo.js
+++ b/lib/geo.js
@@ -11,8 +11,9 @@
 this.version = [0, 0, 1];
 
 // Import HTTP to Request Geocode
-var http = require('http');
 var geohash = require('geohash');
+var Shred = require( 'shred' );
+var shred = new Shred();
 
 // Google Geocode Provider
 function GoogleGeocoder() {};
@@ -36,9 +37,7 @@ GoogleGeocoder.prototype.request = function(location, sensor) {
 };
 
 // Google Geocode Provider - Response
-GoogleGeocoder.prototype.responseHandler = function(response, callback) {
-	var json = JSON.parse(response);
-
+GoogleGeocoder.prototype.responseHandler = function(json, callback ) {
     var _details = function (data) {
         var details = {};
         data.address_components.map(function (d) {
@@ -50,7 +49,7 @@ GoogleGeocoder.prototype.responseHandler = function(response, callback) {
         return details;
     };
 
-	if ( json.results == null || json.results[0] == null ) {
+	if ( json == null || json.results == null || json.results[0] == null ) {
 		callback(null, null, null, null);
 	} else {
 		callback( json.results[0].formatted_address, json.results[0].geometry.location.lat, json.results[0].geometry.location.lng, _details(json.results[0]));
@@ -75,10 +74,8 @@ OSMnominatim.prototype.request = function(location, sensor) {
 };
 
 // OSM nominatim Provider - Response
-OSMnominatim.prototype.responseHandler = function(response, callback) {
-	var json = JSON.parse(response);
-
-	if ( json.length == null || json[0] == null ) {
+OSMnominatim.prototype.responseHandler = function(json, callback) {
+	if ( json == null || json.length == null || json[0] == null ) {
 		callback(null, null, null, null);
 	} else {
 		callback(
@@ -113,7 +110,7 @@ Geo.prototype.init = function() {
 };
 
 // Get Geocode
-Geo.prototype.geocoder = function(geocoder, location, sensor, callback) {
+Geo.prototype.geocoder = function(geocoder, location, sensor, callback, timeout) {
 	// Check Input
 	if ( geocoder == null ) {
 		throw new Error("Invalid Geocoder");
@@ -132,23 +129,22 @@ Geo.prototype.geocoder = function(geocoder, location, sensor, callback) {
 	var options = geocoder.request(location, sensor);
 
 	// Make Request
-	var connection = http.createClient(options.port, options.host);
-    var request = connection.request("GET", options.path);
-
-    // Handle Response
-    request.addListener("response", function (response) {
-    	var responseBody = "";
-    	response.addListener("data", function(chunk) {
-    		responseBody += chunk;
-    	});
-    	response.addListener("end", function() {
-    		geocoder.responseHandler(responseBody, callback);
-    	});
-    });
-
-    // End Request - Listener will take care of Response
-    request.end();
-
+    shred.get({
+        timeout: timeout ? timeout : ( 60 * 1000 ),
+        url: "http://" + options.host + ":" + options.port + options.path,
+        on: {
+            response: function( response ) {
+                geocoder.responseHandler( response.content.data, callback );
+            },
+            error: function( response ) {
+                geocoder.responseHandler( null, callback );
+            },
+            timeout: function() {
+                geocoder.responseHandler( null, callback );
+            }
+        }
+    });        
+    
 };
 
 // Get GeoHash

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "url": "git@github.com:feliperazeek/geonode.git"
   },
   "licenses"      : ["MIT"],
-  "dependencies"  : ["geohash"],
+  "dependencies": {
+    "geohash": "0.0.x",
+    "shred": "0.7.x"
+  },
   "lib"           : "lib",
   "main"          : "./lib/geo",
   "version"       : "0.0.3",


### PR DESCRIPTION
This uses Shred to support setting a timeout on geocoding requests (and to make handling the requests a bit nicer).
