### PR TITLE
Replaced use of deprecated escape() with encodeURLComponent()

### DIFF
--- a/lib/geo.js
+++ b/lib/geo.js
@@ -22,10 +22,10 @@ function GoogleGeocoder() {};
 GoogleGeocoder.prototype.request = function(location, sensor) {
   if (typeof location == 'object' && location['latitude'] != null && location['longitude'] != null) {
     // if location is an object with lat and long properties, we do reverse geocoding
-    var path = '/maps/api/geocode/json?latlng=' + escape(location['latitude'].toString() + ',' + location['longitude'].toString()) + '&sensor=' + sensor;
+    var path = '/maps/api/geocode/json?latlng=' + encodeURIComponent(location['latitude'].toString() + ',' + location['longitude'].toString()) + '&sensor=' + sensor;
   } else {
     // normal forward geocoding
-    var path = '/maps/api/geocode/json?address=' + escape(location) + '&sensor=' + sensor;
+    var path = '/maps/api/geocode/json?address=' + encodeURIComponent(location) + '&sensor=' + sensor;
   }
 
 	return {
@@ -63,7 +63,7 @@ function OSMnominatim() {};
 OSMnominatim.prototype.request = function(location, sensor) {
 
 	// Path information: http://wiki.openstreetmap.org/wiki/Nominatim
-	var path = '/search/?format=json&q=' + escape(location) + '&sensor=' + sensor;
+	var path = '/search/?format=json&q=' + encodeURIComponent(location) + '&sensor=' + sensor;
 
 	return {
 		host: 'nominatim.openstreetmap.org',


### PR DESCRIPTION
I couldn't get the library to fetch addresses with non-ascii characters. This change fixed the issue.

According to the thread below, escape has been deprecated for a long time.
http://stackoverflow.com/questions/75980/best-practice-escape-or-encodeuri-encodeuricomponent
